### PR TITLE
Unify the way of passing headers for get method

### DIFF
--- a/lib/rest/client_honeypot.rb
+++ b/lib/rest/client_honeypot.rb
@@ -6,6 +6,13 @@ require 'restclient'
 
 # rubocop:disable Style/Documentation
 module RestClient
+  def self.get(url, headers = {}, &block)
+    headers_kwarg = headers.delete(:headers)
+    headers.merge!(headers_kwarg) if headers_kwarg
+
+    RestClient::Request.execute(method: :get, url: url, headers: headers, &block)
+  end
+
   def self.post(url, payload, headers = {}, &block)
     payload, headers = with_json(payload, headers)
     RestClient::Request.execute(method: :post, url: url, payload: payload, headers: headers, &block)

--- a/rest-client_honeypot.gemspec
+++ b/rest-client_honeypot.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'rest-client_honeypot'
-  spec.version       = '0.0.10'
+  spec.version       = '0.0.11'
   spec.authors       = ['Andrzej Trzaska']
   spec.email         = ['atrzaska2@gmail.com']
 


### PR DESCRIPTION
Because http get does not accept body payload in restclient, passing headers is different in restclient get method compared to other http verbs. This PR unifies the way of passing headers as keyword argument


```
irb(main):001:0> RestClient.get('https://google.com', headers: { foo: 'true' })


From: /Users/andrzej/Documents/honeypot/restclient_honeypot/lib/rest/client_honeypot.rb:13 RestClient.get:

     9: def self.get(url, headers = {}, &block)
    10:   headers_kwarg = headers.delete(:headers)
    11:   headers.merge!(headers_kwarg) if headers_kwarg
    12:
 => 13:   binding.pry
    14:   RestClient::Request.execute(method: :get, url: url, headers: headers, &block)
    15: end

[1] pry(RestClient)> headers
=> {:foo=>"true"}
[2] pry(RestClient)> exit
```

Excon http client does not have this problem.